### PR TITLE
flick->drag threshold and extra callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If a projection is defined globally, and not specified in the function call, the
 
 - *time*: reference time for the inertia (in ms, default 5000)
 
-- *hold*: threshold time beteen the final *move* and *end* events after which inertia will be cancelled (in ms, default 50)
+- *hold*: threshold time beteen the final *move* and *end* events after which inertia will be cancelled (in ms, default 100)
 
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ If a projection is defined globally, and not specified in the function call, the
 
 *opt* is an array of options, which can include:
 
-- *start*, *move*, *end*: callback functions on the corresponding events
+- *start*, *move*, *end*: callback functions on the corresponding events (*end* is invoked only if conditions for inertia are met)
 
-- *time*: reference time for the interia (in ms, default 5000)
+- *stop*, *finish*: extra callback functions invoked if the conditions for inertia are not met or after it finishes respectively
+
+- *time*: reference time for the inertia (in ms, default 5000)
+
+- *hold*: threshold time beteen the final *move* and *end* events after which inertia will be cancelled (in ms, default 50)
 
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If a projection is defined globally, and not specified in the function call, the
 
 - *start*, *move*, *end*: callback functions on the corresponding events (*end* is invoked only if conditions for inertia are met)
 
-- *stop*, *finish*: extra callback functions invoked if the conditions for inertia are not met or after it finishes respectively
+- *stop*, *finish*: extra callback functions invoked if the conditions for inertia are not met and after it finishes respectively
 
 - *time*: reference time for the inertia (in ms, default 5000)
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export function inertiaHelper(opt) {
       var time = performance.now();
       var deltaTime = time - inertia.time;
       
-      if (opt.hold == undefined) opt.hold = 50; // default flick->drag threshold time (0 disables inertia)
+      if (opt.hold == undefined) opt.hold = 100; // default flick->drag threshold time (0 disables inertia)
       
       if (deltaTime >= opt.hold) return inertia.timer.stop(), opt.stop && opt.stop();
       

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,8 @@ export function geoInertiaDragHelper(opt) {
       v11 = versor.cartesian(projection.invert(inertia.position));
       opt.end && opt.end();
     },
+    stop: opt.stop,
+    finish: opt.finish,
     render: function(t) {
       var rotation = versor.rotation(
         versor.multiply(q10, versor.delta(v10, v11, t * 1000))
@@ -68,7 +70,10 @@ export function geoInertiaDrag(target, render, proj, opt) {
     start: opt.start,
     move: opt.move,
     end: opt.end,
-    time: opt.time
+    stop: opt.stop,
+    finish: opt.finish,
+    time: opt.time,
+    hold: opt.hold
   });
   target.call(
     drag()
@@ -109,10 +114,18 @@ export function inertiaHelper(opt) {
       opt.move && opt.move.call(this, position);
     },
     end: function() {
+      this.classList.remove('dragging', 'inertia');
+      
       var v = inertia.velocity;
-      if (v[0] * v[0] + v[1] * v[1] < 100) return inertia.timer.stop(), this.classList.remove('inertia');
+      if (v[0] * v[0] + v[1] * v[1] < 100) return inertia.timer.stop(), opt.stop && opt.stop();
 
-      this.classList.remove('dragging');
+      var time = performance.now();
+      var deltaTime = time - inertia.time;
+      
+      if (opt.hold == undefined) opt.hold = 50; // default flick->drag threshold time (0 disables inertia)
+      
+      if (deltaTime >= opt.hold) return inertia.timer.stop(), opt.stop && opt.stop();
+      
       this.classList.add('inertia');
       opt.end && opt.end();
 
@@ -124,6 +137,7 @@ export function inertiaHelper(opt) {
           inertia.timer.stop(), me.classList.remove('inertia');
           inertia.velocity = [0, 0];
           inertia.t = 1;
+          opt.finish && opt.finish();
         }
       });
     },


### PR DESCRIPTION
Suggested changes:
- flick->drag threshold 
- extra callbacks (stop, finish)
- bugfix removing "dragging" from classlist if inertia is prevented

I set the default flick->drag threshold to 100 ms. Before, there was no such threshold, so the default behaviour is changed (in my opinion for the better).

Currently the end callback is not invoked if the velocity threshold or new flick->drag threshold prevent inertia.
If that is unintentional, the end and stop callbacks could be combined.

Removing "inertia" from classlist in inertia.end seems unnecessary but I left it in (maybe it was meant to be "dragging" in the first place, that would explain/solve the bug I think).

I have not been able to test the adjusted code in practice 